### PR TITLE
[sonar] Avoid duplications on copied source code

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -85,7 +85,7 @@ jobs:
           SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         run: |
           build-wrapper-linux-x86-64 --out-dir sonarqube-out \
-            platformio ci --build-dir="./bin" --keep-build-dir --project-conf=platformio.ini ./src/main.cpp \
+            platformio ci --build-dir="./bin" --project-conf=platformio.ini ./src/main.cpp \
             --lib="./src/" --lib="./lib/se050/" \
             --lib="./lib/secp256k1-embedded/" --lib="./lib/OSC/" --lib="./lib/libwally-embedded/"
           # Hack - point sonarqube to the real sources not the copy of it


### PR DESCRIPTION
```
You are getting a copy of the source files in ./bin/src because of --build-dir...
```